### PR TITLE
Update for http2-5.3 and upcoming tls

### DIFF
--- a/push-notify-apn.cabal
+++ b/push-notify-apn.cabal
@@ -29,8 +29,9 @@ library
                      , bytestring
                      , containers
                      , data-default
-                     , http2 >= 3.0 && <= 5.1
+                     , http2 >= 3.0 && <= 5.4
                      , http2-client >= 0.10.0.2
+                     , http-types >= 0.12.4
                      , lifted-base
                      , mtl
                      , random


### PR DESCRIPTION
- In http2, `HeaderList` was replaced with `[Header]`, `SettingsHeaderTableSize` was replaced with `SettingsTokenHeaderTableSize`.

- data-default 0.8 deprecates data-default-class by moving the `Default` class from `Data.Default.Class` to `Data.Default`.

- tls has replaced some default instances with functions and made some record constructors private.

See: https://github.com/haskell-grpc-native/http2-client/pull/97
See: https://github.com/kazu-yamamoto/crypton-certificate/pull/11
See: https://github.com/haskell-tls/hs-tls/pull/486
See: https://github.com/commercialhaskell/stackage/issues/7545