### PR TITLE
Use empty string instead of undefined in server id

### DIFF
--- a/src/Network/PushNotify/APN.hs
+++ b/src/Network/PushNotify/APN.hs
@@ -508,7 +508,7 @@ newConnection aci = do
           castore <- getSystemCertificateStore
           let clip = ClientParams
                   { clientUseMaxFragmentLength=Nothing
-                  , clientServerIdentification=(T.unpack hostname, undefined)
+                  , clientServerIdentification=(T.unpack hostname, "")
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing
                   , clientShared=def
@@ -535,7 +535,7 @@ newConnection aci = do
 
               clip = ClientParams
                   { clientUseMaxFragmentLength=Nothing
-                  , clientServerIdentification=(T.unpack hostname, undefined)
+                  , clientServerIdentification=(T.unpack hostname, "")
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing
                   , clientShared=shared


### PR DESCRIPTION
It seems the TLS upgrade caused undefined to get evaluated resulting in breakage on push notifications. Updates to use the empty string instead which should bring us in line with previous behavior