### PR TITLE
Use empty string instead of undefined in server id

### DIFF
--- a/push-notify-apn.cabal
+++ b/push-notify-apn.cabal
@@ -29,8 +29,9 @@ library
                      , bytestring
                      , containers
                      , data-default
-                     , http2 >= 3.0 && <= 5.1
+                     , http2 >= 3.0 && <= 5.4
                      , http2-client >= 0.10.0.2
+                     , http-types >= 0.12.4
                      , lifted-base
                      , mtl
                      , random

--- a/src/Network/PushNotify/APN.hs
+++ b/src/Network/PushNotify/APN.hs
@@ -507,7 +507,7 @@ newConnection aci = do
     clip <- case (aciUseJWT aci) of
         True -> do
           castore <- getSystemCertificateStore
-          let clip = (defaultParamsClient (T.unpack hostname) undefined)
+          let clip = (defaultParamsClient (T.unpack hostname) "")
                   { clientUseMaxFragmentLength=Nothing
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing
@@ -534,7 +534,7 @@ newConnection aci = do
               shared      = def { sharedCredentials = credentials
                                 , sharedCAStore=castore }
 
-              clip = (defaultParamsClient (T.unpack hostname) undefined)
+              clip = (defaultParamsClient (T.unpack hostname) "")
                   { clientUseMaxFragmentLength=Nothing
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing


### PR DESCRIPTION
https://github.com/digitallyinduced/push-notify-apn/pull/1 - required as base. Happy to rebase once that has been merged.

`undefined` is evaluated for us in certain cases with the TLS upgrade resulting in our push notifications not sending. This replaces undefined with an empty string in the server id