### PR TITLE
Add priority support with good defaults

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -92,7 +92,7 @@ send o = do
                         sound   = parts !! 1
                         payload = setSound sound . alertMessage title text $ Nothing
                         message = newMessage payload 
-                    in (sendMessage sess token (jwt o) message >>= TI.putStrLn . T.pack . show) >> loop sess
+                    in (sendMessage sess token (jwt o) Nothing message >>= TI.putStrLn . T.pack . show) >> loop sess
                 else case line of
                     "close" -> closeSession sess >> loop sess
                     "reset" -> mkSession >>= loop
@@ -105,4 +105,4 @@ send o = do
             message  = newMessage payload
         forM_ (tokens o) $ \token ->
             let apntoken = hexEncodedToken . T.pack $ token
-            in sendMessage session apntoken (jwt o) message >>= print
+            in sendMessage session apntoken (jwt o) Nothing message >>= print

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+0.5.0.0
+=======
+
+- Add newWidgetMessage function for creating widget notifications with content-changed flag
+- Add sendWidgetNotification convenience function for sending widget notifications
+- Add ApnPushType enum for specifying push type (currently supports alert, background, and widgets)
+- Add ApnPriority enum for specifying push priority, with defaults based on the push type
+
 0.4.0.3
 =======
 

--- a/push-notify-apn.cabal
+++ b/push-notify-apn.cabal
@@ -1,5 +1,5 @@
 name:                push-notify-apn
-version:             0.4.0.3
+version:             0.5.0.0
 synopsis:            Send push notifications to mobile iOS devices
 description:
     push-notify-apn is a library and command line utility that can be used to send


### PR DESCRIPTION
Apple’s docs say that specifying a priority is recommended (though it will fall back to 10 if one is not specified). And for certain push types, it's required. This adds support for specifying a priority, with a default based on the push type. Also bumps to `0.5.0.0`